### PR TITLE
chore: reconfigure prettier and eslint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,5 +7,8 @@ dist/
 # Dependencies
 node_modules/
 
+# Static assets
+public/
+
 # UI Components
 src/components/ui/**

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,10 +10,10 @@
   "singleQuote": true,
   "tabWidth": 2,
   "useTabs": false,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "printWidth": 80,
   "bracketSpacing": true,
   "bracketSameLine": false,
   "arrowParens": "always",
-  "jsxSingleQuote": true
+  "jsxSingleQuote": false
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,19 @@
 {
-  "singleQuote": true,
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "endOfLine": "lf",
+  "quoteProps": "as-needed",
+  "proseWrap": "preserve",
+  "htmlWhitespaceSensitivity": "css",
+  "vueIndentScriptAndStyle": false,
+  "embeddedLanguageFormatting": "auto",
   "semi": true,
-  "trailingComma": "all",
-  "printWidth": 80,
+  "singleQuote": true,
   "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "es5",
+  "printWidth": 80,
   "bracketSpacing": true,
-  "jsxSingleQuote": false,
-  "jsxBracketSameLine": false,
-  "arrowParens": "always"
+  "bracketSameLine": false,
+  "arrowParens": "always",
+  "jsxSingleQuote": true
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,89 +1,21 @@
 import { FlatCompat } from '@eslint/eslintrc';
-import prettierPlugin from 'eslint-plugin-prettier';
+import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
 import simpleImportSortPlugin from 'eslint-plugin-simple-import-sort';
+import globals from 'globals';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// FlatCompat for eslintrc-style configs
 const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-export default [
-  ...compat.extends('next/core-web-vitals'),
-  ...compat.extends('next'),
-  ...compat.extends('plugin:@typescript-eslint/recommended'),
-  ...compat.extends('plugin:prettier/recommended'),
-  ...compat.extends('airbnb'),
-
-  {
-    rules: {
-      'simple-import-sort/imports': 'error',
-      'simple-import-sort/exports': 'error',
-      'prettier/prettier': 'error',
-      'no-nested-ternary': 'warn',
-      'react/react-in-jsx-scope': 'off',
-      'jsx-a11y/anchor-is-valid': 'off',
-      'react/require-default-props': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'react/jsx-no-bind': 'off',
-      'import/prefer-default-export': 'off',
-      'react/jsx-one-expression-per-line': 'off',
-      'object-curly-newline': 'off',
-      'operator-linebreak': 'off',
-      'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          args: 'after-used',
-          ignoreRestSiblings: true,
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-        },
-      ],
-      'no-underscore-dangle': ['error', { allow: ['__filename', '__dirname'] }],
-      'react/jsx-filename-extension': [
-        'warn',
-        { extensions: ['.tsx', '.jsx'] },
-      ],
-      'class-methods-use-this': 'off',
-      'implicit-arrow-linebreak': 'off',
-      'import/extensions': [
-        'error',
-        'ignorePackages',
-        {
-          js: 'never',
-          jsx: 'never',
-          ts: 'warn',
-          tsx: 'never',
-        },
-      ],
-      camelcase: [
-        'error',
-        {
-          allow: ['Geist_Mono'],
-        },
-      ],
-    },
-    settings: {
-      react: {
-        version: 'detect',
-      },
-      'import/resolver': {
-        typescript: {},
-        alias: {
-          map: [['@', './src/']],
-          extensions: ['.ts', '.tsx', ''],
-        },
-      },
-    },
-    plugins: {
-      prettier: prettierPlugin,
-      'simple-import-sort': simpleImportSortPlugin,
-    },
-  },
+export default defineConfig([
+  // Global ignores
   {
     ignores: [
       '.next',
@@ -102,4 +34,107 @@ export default [
       'src/components/ui/**',
     ],
   },
-];
+
+  // Base ESLint recommended rules
+  js.configs.recommended,
+
+  // Next.js recommended rules with TypeScript support
+  ...compat.extends(
+    'next/core-web-vitals',
+    'next/typescript',
+    'prettier' // Must be last to disable conflicting formatting rules
+  ),
+
+  {
+    files: ['**/*.{js,mjs,cjs,jsx,ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        ...globals.es2025,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    plugins: {
+      'simple-import-sort': simpleImportSortPlugin,
+    },
+    rules: {
+      // Import sorting
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+
+      // TypeScript specific overrides (handled by next/typescript)
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+
+      // Custom rules for better code quality
+      'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+      'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+
+      // Allow specific naming patterns for Next.js/Supabase
+      camelcase: [
+        'error',
+        {
+          allow: [
+            // Next.js font patterns
+            'Geist_Mono',
+            // Supabase User type properties
+            'app_metadata',
+            'user_metadata',
+            'avatar_url',
+            'created_at',
+            'updated_at',
+            'phone_confirmed_at',
+            'email_confirmed_at',
+            'confirmation_sent_at',
+            'recovery_sent_at',
+            'email_change_sent_at',
+            'new_email',
+            'invited_at',
+            'action_link',
+            'email_change',
+            'phone_change',
+          ],
+        },
+      ],
+    },
+  },
+
+  // Configuration for test files
+  {
+    files: ['**/*.test.{js,jsx,ts,tsx}', '**/*.spec.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+
+  // Configuration for config files
+  {
+    files: ['*.config.{js,mjs,ts}', '.*rc.{js,mjs,ts}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig([
       'build/**',
       'dist/**',
       'node_modules/**',
+      'public/**',
       '*.generated.*',
       '*.min.js',
       '**/*.test.*',
@@ -42,7 +43,7 @@ export default defineConfig([
   ...compat.extends(
     'next/core-web-vitals',
     'next/typescript',
-    'prettier' // Must be last to disable conflicting formatting rules
+    'prettier', // Must be last to disable conflicting formatting rules
   ),
 
   {
@@ -80,8 +81,9 @@ export default defineConfig([
       ],
 
       // Custom rules for better code quality
-      'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+      // 'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
+      'no-console': 'warn',
 
       // Allow specific naming patterns for Next.js/Supabase
       camelcase: [

--- a/src/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -31,7 +31,7 @@ export function ForgotPasswordForm({
     });
 
     setEmail('');
-     
+
     alert('Password reset link sent.');
   };
 

--- a/src/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -31,7 +31,7 @@ export function ForgotPasswordForm({
     });
 
     setEmail('');
-    // eslint-disable-next-line no-alert
+     
     alert('Password reset link sent.');
   };
 


### PR DESCRIPTION
I edited these configs because we often ran into conflicts between prettier and eslint, and too strict rules from airbnb. Instead of disabling rules every PR, we should rewrite the linting to be less strict and in accordance with prettier. This is achieved by the following changes.