### PR TITLE
fix: chat message overflow

### DIFF
--- a/src/components/Chat/ChatInterface.tsx
+++ b/src/components/Chat/ChatInterface.tsx
@@ -21,7 +21,7 @@ export default function ChatInterface({
 
       {/* Show streaming message */}
       {streamingMessage && (
-        <p className="whitespace-pre-wrap text-sm leading-relaxed opacity-70">
+        <p className="whitespace-pre-wrap text-sm leading-relaxed opacity-70 break-words overflow-wrap-anywhere">
           {streamingMessage}
         </p>
       )}

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -8,7 +8,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
   if (message.author === 'user') {
     return (
       <div className="flex justify-end">
-        <p className="bg-muted rounded-2xl p-2 px-4 max-w-[75%] whitespace-pre-wrap text-sm leading-relaxed">
+        <p className="bg-muted rounded-2xl p-2 px-4 max-w-[75%] whitespace-pre-wrap text-sm leading-relaxed break-words overflow-wrap-anywhere">
           {message.content}
         </p>
       </div>
@@ -16,7 +16,7 @@ export function ChatMessage({ message }: ChatMessageProps) {
   }
 
   return (
-    <p className="whitespace-pre-wrap text-sm leading-relaxed">
+    <p className="whitespace-pre-wrap text-sm leading-relaxed break-words overflow-wrap-anywhere">
       {message.content}
     </p>
   );


### PR DESCRIPTION
- when sending long continous string, like long URLs, the prev. Message component did not handle line breaks