### PR TITLE
fix chat

### DIFF
--- a/src/repositories/chatRepository.ts
+++ b/src/repositories/chatRepository.ts
@@ -82,8 +82,6 @@ export const chatRepository = {
     const token = getCookie('token');
 
     try {
-      console.log('start new message');
-      console.log(token);
       const response = await fetch(`${API_BASE_URL}/chat/`, {
         method: 'POST',
         mode: 'cors',


### PR DESCRIPTION
In chat-actions.ts, you are calling getCookie('token') on the server (in a server action).
In server actions, getCookie from cookies-next does not work as expected because it relies on the request context, which is not available in server actions.
In profileRepository.ts, you are likely calling it on the client, where getCookie works as expected.